### PR TITLE
Expose User info to consuming apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,21 @@ Here is the format of the ```request.env['omniauth.auth']``` hash:
 {
   "provider"=>"ds_auth",
   "uid"=>"4d663e19-8e63-4cd0-800d-dabdc3f51fe5",
-  "info"=>{},
+  "info"=>{
+    "name" => "Bob Smith",
+    "email" => "bob@example.com",
+    "phone" => "02071234567",
+    "mobile" => "071234567",
+    "full_address" => "1 Fake Steet",
+    "postcode" => "AB1 2CD",
+    "organisations" => [
+      {
+        "uid" => "b2e402e4-6e44-485b-87b8-b47343cfbedb",
+        "name" => "Bobs Company",
+        "roles" => ["admin", "viewer"]
+      }
+    ]
+  },
   "credentials"=>{
     "token"=>"41f7784aa87373426d0990cf8ed97203a0c20856bf83a77ca62fcbe302377710",
     "expires_at"=>1436871976,
@@ -151,11 +165,14 @@ Here is the format of the ```request.env['omniauth.auth']``` hash:
 
 Notes:
 
-* uid is the unique identifer for the current user
+* *uid* is the unique identifer for the current user
+* *organisations* is the list of organisations this user belongs to, with the roles that user has within *that* organisation
+* a User may belong to multiple organisations, with multiple roles in each
 
 
 ### Authorization
-If the User does not have any roles for the application (as returned by the profile API response) then the session will be cleared and the User redirected to the authentication error page.
+If the User does not have any roles for the application (as returned by the profile API response) then the organisations array will be empty.
+It is up to the consuming application to decide what to do then.
 
 Likewise if configured in the Auth App if current_user does not have permission to access the application then the Authentication provider will redirect to `auth/failure?message=unauthorized` rather than the sessions#create route. See [https://github.com/intridea/omniauth/wiki](https://github.com/intridea/omniauth/wiki)
 

--- a/lib/ds-auth-omniauth/lib/user.rb
+++ b/lib/ds-auth-omniauth/lib/user.rb
@@ -1,7 +1,8 @@
 module DsAuth
   module Omniauth
     class User
-      attr_reader :uid, :email, :name, :organisations
+      attr_reader :uid, :email, :name, :phone, :mobile,
+        :full_address, :postcode, :organisations
 
       def self.build_from(auth_hash)
         user = auth_hash.fetch("user")
@@ -9,14 +10,22 @@ module DsAuth
           uid:   user.fetch("uid"),
           name:  user.fetch("name"),
           email: user.fetch("email"),
+          phone: user.fetch("telephone"),
+          mobile: user.fetch("mobile"),
+          full_address: user.fetch("address").fetch("full_address"),
+          postcode: user.fetch("address").fetch("postcode"),
           organisations: Array(user.fetch("organisations"))
         )
       end
 
-      def initialize(uid:, name:, email:, organisations:)
+      def initialize(uid:, name:, email:, phone: "", mobile: "", full_address: "", postcode: "", organisations: [])
         @uid   = uid
         @name  = name
         @email = email
+        @phone = phone
+        @mobile = mobile
+        @full_address = full_address
+        @postcode = postcode
         @organisations = organisations
       end
     end

--- a/spec/ds-auth-omniauth/lib/user_spec.rb
+++ b/spec/ds-auth-omniauth/lib/user_spec.rb
@@ -5,16 +5,14 @@ require "omniauth"
 RSpec.describe DsAuth::Omniauth::User, ".build_from" do
   it "builds a user from the auth hash" do
     organisation_1 = {
-        "uuid" => "CUSTODY-SUITE-UID",
+        "uid" => "CUSTODY-SUITE-UID",
         "name" => "Custody Suite London",
-        "type" => "custody_suite",
-        "roles" => ["cso", "admin"]
+        "roles" => ["user", "admin"]
     }
     organisation_2 = {
-        "uuid" => "LAW-FIRM-UID",
+        "uid" => "LAW-FIRM-UID",
         "name" => "Law Firm Blecthley",
-        "type" => "law_firm",
-        "roles" => ["solicitor"]
+        "roles" => ["viewer"]
     }
     auth_hash = {
       "user" => {
@@ -23,12 +21,9 @@ RSpec.describe DsAuth::Omniauth::User, ".build_from" do
           "telephone" => "0123456789",
           "mobile"    => "071234567",
           "address"   => {
-              "line1"    => "",
-              "line2"    => "",
-              "city"     => "",
-              "postcode" => ""
+              "full_address" => "1 Fake Street",
+              "postcode" => "AB1 2CD"
           },
-          "PIN"              => "1234",
           "organisations" => [ organisation_1, organisation_2 ],
           "uid"   => "12345678-abcd-1234-abcd-1234567890"
       }
@@ -36,9 +31,11 @@ RSpec.describe DsAuth::Omniauth::User, ".build_from" do
 
     user = DsAuth::Omniauth::User.build_from auth_hash
 
-    expect(user.uid).to   eq "12345678-abcd-1234-abcd-1234567890"
-    expect(user.name).to  eq "Bob Smith"
-    expect(user.email).to eq "bob.smith@world.com"
+    expect(user.uid).to    eq "12345678-abcd-1234-abcd-1234567890"
+    expect(user.name).to   eq "Bob Smith"
+    expect(user.email).to  eq "bob.smith@world.com"
+    expect(user.phone).to  eq "0123456789"
+    expect(user.mobile).to eq "071234567"
     expect(user.organisations).to match_array([organisation_1, organisation_2])
   end
 end

--- a/spec/omniauth/strategies/ds_auth_spec.rb
+++ b/spec/omniauth/strategies/ds_auth_spec.rb
@@ -35,6 +35,65 @@ describe "ds_auth strategy" do
     end
   end
 
+  describe "#uid" do
+    it "returns the users uid from the raw info" do
+      expect(subject).to receive(:raw_info).and_return({"user" => {"uid" => "abcdef"}})
+
+      expect(subject.uid).to eq("abcdef")
+    end
+  end
+
+  describe "#info" do
+    before do
+      json = File.read(File.expand_path(File.join(__FILE__, "../../../support/me.json"))).gsub('\\n','')
+      allow(subject).to receive(:fetch_raw_info).and_return json
+    end
+
+    it "has user name" do
+      expect(subject.info["name"]).to eq("Bob Smith")
+    end
+
+    it "has user email" do
+      expect(subject.info["email"]).to eq("bob@example.com")
+    end
+
+    it "has user phone" do
+      expect(subject.info["phone"]).to eq("01234567890")
+    end
+
+    it "has user mobile" do
+      expect(subject.info["mobile"]).to eq("07123456789")
+    end
+
+    it "has user full_address" do
+      expect(subject.info["full_address"]).to eq("1 Fake Street")
+    end
+
+    it "has user postcode" do
+      expect(subject.info["postcode"]).to eq("AB1 2CD")
+    end
+
+    it "has an array of organisations the user belongs to" do
+      expect(subject.info["organisations"]).to be_a Array
+    end
+
+    describe "organisations" do
+      let(:organisation) { subject.info["organisations"].first }
+
+      it "has a uid" do
+        expect(organisation["uid"]).to eq("b2e402e4-6e44-485b-87b8-b47343cfbedb")
+      end
+
+      it "has a name" do
+        expect(organisation["name"]).to eq("Bobs Company")
+      end
+
+      it "has roles the user has within that organisation" do
+        expect(organisation["roles"]).to eq(["admin", "viewer"])
+      end
+    end
+  end
+
   describe "raw_info" do
     before do
       allow(fake_access_token).to receive(:get).and_return fake_response

--- a/spec/support/me.json
+++ b/spec/support/me.json
@@ -1,0 +1,20 @@
+{
+  "uid":"4d663e19-8e63-4cd0-800d-dabdc3f51fe5",
+  "user":{
+    "email":"bob@example.com",
+    "name":"Bob Smith",
+    "telephone":"01234567890",
+    "mobile":"07123456789",
+    "address":{
+      "full_address":"1 Fake Street",
+      "postcode":"AB1 2CD"
+    }
+  },
+  "organisations":[
+    {
+      "uid":"b2e402e4-6e44-485b-87b8-b47343cfbedb",
+      "name":"Bobs Company",
+      "roles":["admin", "viewer"]
+    }
+  ]
+}


### PR DESCRIPTION
* expose user info in omniauth.auth hash
* expose organisations a user belongs to in omniauth.auth hash
* remove explict role check from controller mixin - consuming apps can do themselves if needed
* expose user phone, mobile and address in User object